### PR TITLE
Migrate to Express 4.12 and Baucis 1.1

### DIFF
--- a/backend/client/js/general/generalServices.js
+++ b/backend/client/js/general/generalServices.js
@@ -1,7 +1,7 @@
 angular.module('bauhaus.general.services', []);
 
 angular.module('bauhaus.general.services').factory('Documents', function ($resource) {
-    return $resource('api/Documents', {}, {
+    return $resource('api/documents', {}, {
         get: {
             method: 'GET',
             isArray: false

--- a/content/api.js
+++ b/content/api.js
@@ -1,13 +1,12 @@
 var baucis = require('baucis'),
     async = require('async'),
-    Content = require('./model/content')
-    populateConfig = require('../document/helper').populateConfig;
+    Content = require('./model/content'),
+    mongoose = require('mongoose'),
+    populateConfig = require('../document/helper').populateConfig,
+    express = require('express');
 
 module.exports = function (bauhausConfig) {
-    var controller = baucis.rest({
-        singular:'Content', 
-        select:'_type content meta _page', swagger: true
-    });
+    var controller = baucis.rest(mongoose.model('Content')).select('_type content meta _page');
 
     // Populates fields for both single or collection queries
     controller.request('get', function populateReferences (req, res, next) {
@@ -25,11 +24,10 @@ module.exports = function (bauhausConfig) {
         next();
     });
 
-    var api = baucis();
 
-    api.get('/ContentTypes', function (req, res, next) {
+    controller.get('/ContentTypes', function (req, res, next) {
         res.json(bauhausConfig.contentTypes);
     });
 
-    return api;
+    return controller;
 }

--- a/document/api.js
+++ b/document/api.js
@@ -3,7 +3,7 @@ var express = require('express');
 module.exports = function (bauhausConfig) {
     var app = express();
 
-    app.get('/Documents', function (req, res, next) {
+    app.get('/documents', function (req, res, next) {
         res.json(bauhausConfig.documents);
     });
 

--- a/document/client/document/documentServices.js
+++ b/document/client/document/documentServices.js
@@ -2,6 +2,7 @@ angular.module('bauhaus.document.services', []);
 
 angular.module('bauhaus.document.services').factory('DocumentService', function ($resource) {
     return function (type) {
+        type = type.toLowerCase();
         return $resource('api/' + type + '/:id', { id: '@_id' }, {
             get: {
                 method: 'GET',

--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
     "should": "~3.1.2"
   },
   "peerDependencies": {
-    "express": "~3.5.3",
-    "mongoose": "~3.8.12",
-    "baucis": "0.18.x",
-    "debug": "0.8.x",
+    "express": "~4.12.3",
+    "mongoose": "3.x.x",
+    "baucis": "1.1.x",
+    "debug": "^2.1.3",
     "passport": "0.2.x",
     "passport-local": "1.0.x",
     "passport-local-mongoose": "^1.0.0",
     "connect-flash": "0.1.x",
-    "connect-mongo": "0.4.x",
+    "connect-mongo": "0.8.x",
     "mongoose-materialized": "0.1.x",
     "ejs": "2.3.x"
   },

--- a/page/api.js
+++ b/page/api.js
@@ -1,12 +1,11 @@
 var baucis = require('baucis'),
-    Page = require('./model/page');
+    Page = require('./model/page'),
+    mongoose = require('mongoose'),
+    express = require('express');
 
 module.exports = function (bauhausConfig) {
 
-    var pageController = baucis.rest({
-        singular:'Page', 
-        select:'_type _w name route title label parentId path public isSecure roles'
-    });
+    var pageController = baucis.rest(mongoose.model('Page')).select('_type _w name route title label parentId path public isSecure roles');
 
     var getTree = function (request, response, next) {
         // Setting pageId to null finds root
@@ -26,14 +25,14 @@ module.exports = function (bauhausConfig) {
         });
     };
 
-    pageController.get('/getTree/:id?', getTree);
+    var app = express();
 
-    // Create page REST middleware
-    var api = baucis({swagger:true});    
+    pageController.get('/gettree/:id?', getTree);
+  
     // Add page Types to API
-    api.get('/PageTypes', function (req, res) {
+    pageController.get('/pagetypes', function (req, res) {
         res.json(bauhausConfig.pageTypes);
     });
 
-    return api;
+    return pageController;
 }

--- a/page/client/page/pageDirectives.js
+++ b/page/client/page/pageDirectives.js
@@ -27,12 +27,15 @@ angular.module('bauhaus.page.directives').directive('bauhausForm', function ($co
         },
         link: function (scope, el, attr) {
             var html ='<div>';
-            for (var f in scope.config.fields) {
-                var field = scope.config.fields[f];
-                html += '<bauhaus-' + field.type +
-                        ' ng-model="content.content.' + field.name  +
-                        '" field-config="config.fields[' + f + ']" ></bauhaus-' + field.type + '>';
+            if (scope.config && scope.config.fields) {
+                for (var f in scope.config.fields) {
+                    var field = scope.config.fields[f];
+                    html += '<bauhaus-' + field.type +
+                            ' ng-model="content.content.' + field.name  +
+                            '" field-config="config.fields[' + f + ']" ></bauhaus-' + field.type + '>';
+                }   
             }
+            
             html += '</div>';
 
             el.replaceWith($compile(html)(scope));

--- a/page/client/page/pageServices.js
+++ b/page/client/page/pageServices.js
@@ -1,7 +1,7 @@
 angular.module('bauhaus.page.services', []);
 
 angular.module('bauhaus.page.services').factory('Page', function ($resource) {
-    return $resource('api/Pages/:pageId', {}, {
+    return $resource('api/pages/:pageId', {}, {
         get: {
             method: 'GET',
             params: { pageId: 'pageId' },
@@ -19,7 +19,7 @@ angular.module('bauhaus.page.services').factory('Page', function ($resource) {
 });
 
 angular.module('bauhaus.page.services').factory('PageTree', function ($resource) {
-    return $resource('api/Pages/getTree', {}, {
+    return $resource('api/pages/gettree', {}, {
         get: {
             method: 'GET',
             isArray: false
@@ -154,7 +154,7 @@ angular.module('bauhaus.page.services').factory('SharedPageTree', function (Page
 
 
 angular.module('bauhaus.page.services').factory('PageType', function ($resource) {
-    return $resource('api/PageTypes', {}, {
+    return $resource('api/pages/pagetypes', {}, {
         get: {
             method: 'GET',
             isArray: false
@@ -180,7 +180,7 @@ angular.module('bauhaus.page.services').factory('SharedPageType', function (Page
 });
 
 angular.module('bauhaus.page.services').factory('ContentType', function ($resource) {
-    return $resource('api/ContentTypes', {}, {
+    return $resource('api/contents/contenttypes', {}, {
         get: {
             method: 'GET',
             isArray: false
@@ -206,7 +206,7 @@ angular.module('bauhaus.page.services').factory('SharedContentType', function (C
 });
 
 angular.module('bauhaus.page.services').factory('Content', function ($resource) {
-    return $resource('api/Contents/:contentId', {}, {
+    return $resource('api/contents/:contentId', {}, {
         get: {
             method: 'GET',
             params: { contentId: '@_id' }
@@ -227,7 +227,7 @@ angular.module('bauhaus.page.services').factory('Content', function ($resource) 
 });
 
 angular.module('bauhaus.page.services').factory('PageContent', function ($resource) {
-    return $resource('api/Contents?conditions={"_page":":pageId"}', {}, {
+    return $resource('api/contents?conditions={"_page":":pageId"}', {}, {
         get: {
             method: 'GET',
             params: { pageId: '@pageId' },

--- a/security/api.js
+++ b/security/api.js
@@ -1,18 +1,12 @@
 var baucis = require('baucis'),
+    mongoose = require('mongoose'),
     Role = require('./model/role'),
     User = require('./model/user');
 
 module.exports = function (bauhausConfig) {
+    var roleController = baucis.rest(mongoose.model('Role')).select('name permissions');
 
-    var roleController = baucis.rest({
-        singular:'Role', 
-        select:'name permissions', swagger: true
-    });
-
-    var userController = baucis.rest({
-        singular:'User', 
-        select:'username roles fields', swagger: true
-    });
+    var userController = baucis.rest(mongoose.model('User')).select('username roles fields');
 
     /* Middleware which is add for put method (=update user) to store password after user was stored */
     userController.query('put', function (req, res, next) {
@@ -33,10 +27,7 @@ module.exports = function (bauhausConfig) {
         }
     });
 
-
-    api = baucis();
-
-    api.get('/CurrentUser', function (req, res, next) {
+    userController.get('/currentuser', function (req, res, next) {
         if (req.session.user) {
             var user = {
                 id: req.session.user.id,
@@ -53,13 +44,16 @@ module.exports = function (bauhausConfig) {
         }
     }); 
 
-    api.get('/CustomUserFields', function (req, res, next) {
+    userController.get('/customuserfields', function (req, res, next) {
         res.json(bauhausConfig.customUserFields);
     });
 
-    api.get('/Permissions', function (req, res, next) {
+    userController.get('/currentuser/permissions', function (req, res, next) {
         res.json(bauhausConfig.security.permissions)
     });
 
-    return api;
+    return {
+        userController: userController,
+        roleController: roleController
+    };
 };

--- a/security/client/role/roleServices.js
+++ b/security/client/role/roleServices.js
@@ -1,7 +1,7 @@
 angular.module('bauhaus.role.services', []);
 
 angular.module('bauhaus.role.services').factory('Role', function ($resource) {
-    return $resource('api/Roles/:roleId', { roleId: '@_id' }, {
+    return $resource('api/roles/:roleId', { roleId: '@_id' }, {
         get: {
             method: 'GET',
             params: { roleId: 'roleId' },
@@ -49,7 +49,7 @@ angular.module('bauhaus.role.services').factory('SharedRoles', function ($rootSc
 });
 
 angular.module('bauhaus.role.services').factory('Permission', function ($resource) {
-    return $resource('api/Permissions', {}, {
+    return $resource('api/users/currentuser/permissions', {}, {
         query: {
             method: 'GET',
             isArray: false

--- a/security/client/user/userServices.js
+++ b/security/client/user/userServices.js
@@ -1,7 +1,7 @@
 angular.module('bauhaus.user.services', []);
 
 angular.module('bauhaus.user.services').factory('CurrentUser', function ($resource) {
-    return $resource('api/CurrentUser', {}, {
+    return $resource('api/users/currentuser', {}, {
         get: {
             method: 'GET',
             isArray: false

--- a/tag/api.js
+++ b/tag/api.js
@@ -1,13 +1,10 @@
 var baucis = require('baucis')
-    Tag = require('./model/tag');
+    Tag = require('./model/tag'),
+    mongoose = require('mongoose');
 
 module.exports = function (bauhausConfig) {
 
-    var tagController = baucis.rest({
-        singular: 'Tag'
-    });
+    var tagController = baucis.rest(mongoose.model('Tag'));
 
-    var app = baucis(); 
-
-    return app;   
+    return tagController;   
 };


### PR DESCRIPTION
API Files are now returning Baucis controllers instead of Express apps,
baucis.rest() calls are updated to new syntex, all backend api routes
refactored to lower string (partly forced by change in baucis, manual
routes were updated for consistency), some routes were updated
because all manual defined routes now have to use the suffix of its
controller (e.g. /users/currentuser).